### PR TITLE
move vignette index entry to HTML comment

### DIFF
--- a/vignettes/intro_to_vcfR.Rmd
+++ b/vignettes/intro_to_vcfR.Rmd
@@ -1,14 +1,16 @@
+
 ---
 title: "Introduction to vcfR"
 author: "Brian J. Knaus"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Introduction to vcfR}
-  %\VignetteEngine{knitr::rmarkdown}
   \usepackage[utf8]{inputenc}
 ---
-
+<!---
+  %\VignetteIndexEntry{Introduction to vcfR}
+  %\VignetteEngine{knitr::rmarkdown}
+--->
 
 vcfR is a package intended to help people view, understand and filter data in vcf format files.
 


### PR DESCRIPTION
I looked at what the [magrittr vignette](https://github.com/smbache/magrittr/blob/master/vignettes/magrittr.Rmd) looked like and noticed that the %Vignette comment blocks were commented in the HTML. This might work for your situation.