### PR TITLE
missed acronym

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vcfR
 Title: Tools for Working with Variant Call Format ('VCF') Files
-Description: Tools for working with variant call format ('VCF') files. Reads in 'VCF', 'GFF' and 'FASTA' data for visualization.  Includes tools for filtering and writing to vcf format.
+Description: Tools for working with variant call format ('VCF') files. Reads in 'VCF', 'GFF' and 'FASTA' data for visualization.  Includes tools for filtering and writing to 'VCF' files.
 Version: 1.0.0
 Authors@R: c(person(c('Brian', 'J.'), 'Knaus', role = c('cre', 'aut'),
     email = 'briank.lists@gmail.com'),


### PR DESCRIPTION
Additionally, I changed format -> file because variant call format format is awkward.