### PR TITLE
Count "1/0" genotypes as having alt alleles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,9 @@ Authors@R: c(person(c('Brian', 'J.'), 'Knaus', role = c('cre', 'aut'),
     person(c('Niklaus', 'J.'), 'Grunwald', role = 'aut',
     email = 'grunwaln@science.oregonstate.edu'),
     person(c('Eric', 'C.'), 'Anderson', role = 'ctb',
-    email = 'eric.anderson@noaa.gov'))
+    email = 'eric.anderson@noaa.gov'),
+    person(c('David', 'J.'), 'Winter', role = 'ctb',
+    email = 'david.winter@gmail.com'))
 Maintainer: Brian J. Knaus <briank.lists@gmail.com>
 Depends:
     R (>= 3.0.1)

--- a/R/vcfR_conversion.R
+++ b/R/vcfR_conversion.R
@@ -118,6 +118,7 @@ vcfR2genlight <- function(x, n.cores=1){
   x[x=="1|1"] <- 2
   x[x=="0/0"] <- 0
   x[x=="0/1"] <- 1
+  x[x=="1/0"] <- 1
   x[x=="1/1"] <- 2
 
   #  dim(x)


### PR DESCRIPTION
Prior to this commit the conversion function only considered genotypes
with "0/1". It seems some files will switch between encodings from
record to record.

(The 1|0 encoding was already covered)