### PR TITLE
Move travis to container based build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 # Sample .travis.yml for R projects
 
 language: r
+r:
+    - release
+    - devel
+
+cache: packages
 warnings_are_errors: true
-sudo: required
+sudo: false 
 
 r_github_packages:
   - jimhester/covr


### PR DESCRIPTION
I noticed that the runs for vcfR were taking ~ 20m to complete.
I have modified the travis yaml file to switch over to the container
based infastructure as outlined here: https://docs.travis-ci.com/user/languages/r

 - sudo is false because the containers don't allow it
 - packages are cached so they aren't rebuilt every time. They
   are only rebuilt when they are updated; this saves a buttload of time.
 - r-devel was added because it doesn't really cost much more time.

Note: the initial caching will take just as long as a non-container build, but it will go much faster in subsequent builds.