### PR TITLE
Add `on.exit()` to `heatmap.bp()`

### DIFF
--- a/R/heatmap_bp.R
+++ b/R/heatmap_bp.R
@@ -97,6 +97,15 @@ heatmap.bp <- function(x, cbarplot = TRUE, rbarplot = TRUE,
   # Handle column names.
   if(is.null(colnames(x))){colnames(x) <- 1:ncol(x)}
   if(is.null(rownames(x))){rownames(x) <- 1:nrow(x)}
+  
+  
+  # Get user's par(), ignoring the read-only variables.
+  userpar <- graphics::par(no.readonly = TRUE)
+  # Promise to reset graphics device
+  on.exit({
+    graphics::par(userpar)
+  })
+
 
   # Set plot geometry.
   if( cbarplot == FALSE & rbarplot == FALSE & legend == FALSE ){
@@ -182,11 +191,6 @@ heatmap.bp <- function(x, cbarplot = TRUE, rbarplot = TRUE,
       graphics::text(0.5, mp[nrow(mp),1], "High", col="#FFFFFF", adj=c(0.5,1))
     }
   }
-  
-  # Reset graphics device.
-  graphics::par(mfrow=c(1,1))
-  graphics::par(mar=c(5,4,4,2))
-  #
   invisible(NULL)
 }
 


### PR DESCRIPTION
In the current github version of vcfR,
`heatmap.bp()` resets the plot parameters if the
function successfully exits, but if it errors, then
the plot parameters are not reset.

This fix preserves the user's current plotting
parameters and restores them when the function
exits, whether or not an error has occurred.

## Examples

### Current

```r
library(vcfR)
x  <- as.matrix(mtcars)
heatmap.bp(x, col.ramp = "greem")
```

![image](https://cloud.githubusercontent.com/assets/3639446/18798606/2a255b2c-8188-11e6-89db-4bb6e8f9ab17.png)

The next plot is trapped in the layout of heatmap.bp

```r
plot(1:10)
```

![image](https://cloud.githubusercontent.com/assets/3639446/18798675/78fdf20e-8188-11e6-916e-3ebedb455c95.png)


### Fix

```r
library(vcfR)
x  <- as.matrix(mtcars)
heatmap.bp(x, col.ramp = "greem")
```
![image](https://cloud.githubusercontent.com/assets/3639446/18798606/2a255b2c-8188-11e6-89db-4bb6e8f9ab17.png)

The user's par is restored :)

```r
plot(1:10)
```
![image](https://cloud.githubusercontent.com/assets/3639446/18798616/3556ca80-8188-11e6-9143-4b65dd459fcb.png)

