### PR TITLE
Add preserve argument to masker

### DIFF
--- a/man/chromR_functions.Rd
+++ b/man/chromR_functions.Rd
@@ -8,7 +8,7 @@
 \title{chromR_functions}
 \usage{
 masker(x, min_QUAL = 1, min_DP = 1, max_DP = 10000, min_MQ = 20,
-  max_MQ = 100, ...)
+  max_MQ = 100, preserve = FALSE, ...)
 
 variant.table(x)
 
@@ -26,6 +26,9 @@ win.table(x)
 \item{min_MQ}{minimum mapping quality}
 
 \item{max_MQ}{maximum mapping quality}
+
+\item{preserve}{a logical indicating whether or not to preserve the state of
+the current mask field. Defaults to \code{FALSE}}
 
 \item{...}{arguments to be passed to methods}
 }
@@ -48,4 +51,3 @@ The function \strong{variant.table} creates a data.frame containing information 
 
 The funciton \strong{win.table}
 }
-

--- a/tests/testthat/test_2_chromR.R
+++ b/tests/testthat/test_2_chromR.R
@@ -149,6 +149,24 @@ test_that("We implemented the mask",{
   expect_true( sum(chrom@var.info[,'mask']) < nrow(chrom@var.info) )
 })
 
+chrom_preserve_mask <- masker(chrom, min_QUAL = 40, preserve = TRUE)
+chrom_new_mask <- masker(chrom, min_QUAL = 40, preserve = FALSE)
+
+test_that("preserve = TRUE preserves the original mask ", {
+  ori_mask <- chrom@var.info[, 'mask']
+  add_mask <- chrom_preserve_mask@var.info[, 'mask']
+  # adding restrictions reduces variants
+  expect_lt(sum(add_mask), sum(ori_mask))
+  # on comparison, the original masked variants are kept
+  expect_equal(sum(ori_mask | add_mask), sum(ori_mask))
+})
+
+test_that("preserve = FALSE removes the mask", {
+  ori_mask <- chrom@var.info[, 'mask']
+  new_mask <- chrom_new_mask@var.info[, 'mask']
+  expect_gt(sum(new_mask), sum(ori_mask))
+  expect_gt(sum(ori_mask | new_mask), sum(new_mask))
+})
 
 
 ##### ##### ##### ##### #####


### PR DESCRIPTION
The preserve argument will allow the user to specify if the original mask should be preserved or discarded. If it's preserved, then all values that are FALSE in the original mask cannot be overwritten to TRUE.