### PR TITLE
update documentation and message for chrom.s and chrom.e

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@ At the present, this is simply a to-do list for ideas to include in the next maj
 # vcfR 1.4.0.9000
 Released on CRAN 2017-XX-XX.
 
-* Deprecated (via message) the parameters 'chrom.s' and 'chrom.e' of 'chromo()', please use 'xlim()' instead.
+* Deprecated the parameters 'chrom.s' and 'chrom.e' of 'chromo()', please use 'xlim' instead.
 * Added `length()` method for chromR objects.
 * `[` method throws warning if FORMAT is omitted.
 * `plot()` for signature 'chromR' handles INFO column when its all NA.

--- a/R/chromo_plot.R
+++ b/R/chromo_plot.R
@@ -52,14 +52,7 @@ chromo <- function( chrom,
   }
   
   if( chrom.s != 1 | !is.null(chrom.e) ){
-    x1 <- if (chrom.s != 1) chrom.s else 1
-    x2 <- if (is.null(chrom.e)) chrom.e else length(chrom)
-    msg <- paste0(
-      "The parameters 'chrom.s' and 'chrom.e' were deprecated in vcfR v1.5.0.\n",
-      "Please use the 'xlim' parameter instead:\n",
-      "\txlim = c(", x1, ", ", x2, ")\n\n",
-      "Subsetting will not take place.")
-    warning(msg, call. = FALSE)
+    stop("The parameters 'chrom.s' and 'chrom.e' were deprecated in vcfR v1.5.0. Please use 'xlim' instead")
   }
   
   myDots <- list(...)

--- a/R/chromo_plot.R
+++ b/R/chromo_plot.R
@@ -11,8 +11,8 @@
 #' @param chrom an object of class chrom.
 #' @param boxp logical specifying whether marginal boxplots should be plotted [T/F].
 #' @param dp.alpha degree of transparency applied to points in dot plots [0-255].
-#' @param chrom.s	start position for the chromosome.
-#' @param chrom.e	end position for the chromosome.
+#' @param chrom.s	start position for the chromosome. (Deprecated. use xlim)
+#' @param chrom.e	end position for the chromosome. (Deprecated. use xlim)
 #' @param drlist1 a named list containing elements to create a drplot
 #' @param drlist2 a named list containing elements to create a drplot
 #' @param drlist3 a named list containing elements to create a drplot
@@ -52,7 +52,14 @@ chromo <- function( chrom,
   }
   
   if( chrom.s != 1 | !is.null(chrom.e) ){
-    stop("The parameters 'chrom.s' and 'chrom.e' were deprecated in vcfR v1.5.0. Please use 'xlim()' instead")
+    x1 <- if (chrom.s != 1) chrom.s else 1
+    x2 <- if (is.null(chrom.e)) chrom.e else length(chrom)
+    msg <- paste0(
+      "The parameters 'chrom.s' and 'chrom.e' were deprecated in vcfR v1.5.0.\n",
+      "Please use the 'xlim' parameter instead:\n",
+      "\txlim = c(", x1, ", ", x2, ")\n\n",
+      "Subsetting will not take place.")
+    warning(msg, call. = FALSE)
   }
   
   myDots <- list(...)

--- a/man/chromo_plot.Rd
+++ b/man/chromo_plot.Rd
@@ -18,9 +18,9 @@ chromoqc(chrom, boxp = TRUE, dp.alpha = 255, ...)
 
 \item{dp.alpha}{degree of transparency applied to points in dot plots [0-255].}
 
-\item{chrom.s}{start position for the chromosome.}
+\item{chrom.s}{start position for the chromosome. (Deprecated. use xlim)}
 
-\item{chrom.e}{end position for the chromosome.}
+\item{chrom.e}{end position for the chromosome. (Deprecated. use xlim)}
 
 \item{drlist1}{a named list containing elements to create a drplot}
 


### PR DESCRIPTION
This addresses #61 

Thank you for adding a message to users if chrom.s and chrom.e are used. Instead of badgering you with suggestions, I figured I'd just make changes and see if you like them. 

I made the following changes:

 - I initially used the `chrom.s` and `chrom.e` arguments based on reading the manual page, so I added "(deprecated. use xlim)" to the arguments. 
 - changed `xlim()` to `xlim` to differentiate between the argument and the ggplot2 function.
 - added some more context to the message that will give the user the proper xlim argument to use since it might not be immediately obvious as to how to use it.
 - changed `stop` to `warning`. If you feel strongly that a deprecation should result in an error, feel free to change it back. I'm of the mind that deprecation is a warning to the user that a feature will be going away (although in this case, the feature is already gone 🙃 , so a `stop()` is most likely appropriate).