### PR TITLE
Modified read.vcfR so that when nrow=0, it's much faster

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -268,6 +268,10 @@ vcf_stats_gz <- function(x) {
     .Call(vcfR_vcf_stats_gz, x)
 }
 
+vcf_stats_no_variants_gz <- function(x) {
+    .Call(vcfR_vcf_stats_no_variants_gz, x)
+}
+
 read_meta_gz <- function(x, stats, verbose) {
     .Call(vcfR_read_meta_gz, x, stats, verbose)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -268,10 +268,6 @@ vcf_stats_gz <- function(x, nrows = -1L) {
     .Call(vcfR_vcf_stats_gz, x, nrows)
 }
 
-vcf_stats_no_variants_gz <- function(x) {
-    .Call(vcfR_vcf_stats_no_variants_gz, x)
-}
-
 read_meta_gz <- function(x, stats, verbose) {
     .Call(vcfR_read_meta_gz, x, stats, verbose)
 }

--- a/R/io_vcfR.R
+++ b/R/io_vcfR.R
@@ -146,7 +146,7 @@ read.vcfR <- function(file, limit=1e7, nrows = -1, skip = 0, cols = NULL, conver
 
   
 #  ram_est <- stats['variants'] * stats['columns'] * 8 + 248
-  ram_est <- memuse::howbig(ifelse(test = is.null(stats['variants']),
+  ram_est <- memuse::howbig(ifelse(test = stats['variants'] == -1,
                                    yes = nrows,
                                    no = stats['variants']),
                             stats['columns'])

--- a/R/io_vcfR.R
+++ b/R/io_vcfR.R
@@ -107,7 +107,12 @@ read.vcfR <- function(file, limit=1e7, nrows = -1, skip = 0, cols = NULL, conver
   }
   
   vcf <- new(Class="vcfR")
-  stats <- .Call('vcfR_vcf_stats_gz', PACKAGE = 'vcfR', file)
+  if (nrows == 0) {
+    stats <- .Call('vcfR_vcf_stats_no_variants_gz', PACKAGE = 'vcfR', file)
+  } else {
+    stats <- .Call('vcfR_vcf_stats_gz', PACKAGE = 'vcfR', file)  
+  }
+  
   # stats should be a named vector containing "meta", "header", "variants", "columns".
   # They should have been initialize to zero.
   if(verbose == TRUE){
@@ -131,7 +136,11 @@ read.vcfR <- function(file, limit=1e7, nrows = -1, skip = 0, cols = NULL, conver
     stop( paste("stats['header'] less than zero:", stats['header'], ", this should never happen.") )
   }
   if( stats['variants'] < 0 ){
-    stop( paste("stats['variants'] less than zero:", stats['variants'], ", this should never happen.") )
+    if (nrows == 0) { 
+      message('No variants read because nrows=0 parameter was set.') 
+    } else {
+      stop( paste("stats['variants'] less than zero:", stats['variants'], ", this should never happen.") )
+    }
   }
   if( stats['columns'] < 0 ){
     stop( paste("stats['columns'] less than zero:", stats['columns'], ", this should never happen.") )

--- a/R/io_vcfR.R
+++ b/R/io_vcfR.R
@@ -107,7 +107,7 @@ read.vcfR <- function(file, limit=1e7, nrows = -1, skip = 0, cols = NULL, conver
   }
   
   vcf <- new(Class="vcfR")
-  if (nrows == 0) {
+  if (nrows != -1) {
     stats <- .Call('vcfR_vcf_stats_no_variants_gz', PACKAGE = 'vcfR', file)
   } else {
     stats <- .Call('vcfR_vcf_stats_gz', PACKAGE = 'vcfR', file)  
@@ -136,11 +136,9 @@ read.vcfR <- function(file, limit=1e7, nrows = -1, skip = 0, cols = NULL, conver
     stop( paste("stats['header'] less than zero:", stats['header'], ", this should never happen.") )
   }
   if( stats['variants'] < 0 ){
-    if (nrows == 0) { 
-      message('No variants read because nrows=0 parameter was set.') 
-    } else {
-      stop( paste("stats['variants'] less than zero:", stats['variants'], ", this should never happen.") )
-    }
+    if (nrows == -1) { 
+      stop( paste("stats['variants'] less than zero:", stats['variants'], ", this should not happen when nrows is unspecified.") )
+    } 
   }
   if( stats['columns'] < 0 ){
     stop( paste("stats['columns'] less than zero:", stats['columns'], ", this should never happen.") )
@@ -154,7 +152,7 @@ read.vcfR <- function(file, limit=1e7, nrows = -1, skip = 0, cols = NULL, conver
   cols <- sort( unique( c(1:8, cols) ) )
 
   
-#  ram_est <- stats['variants'] * stats['columns'] * 8 + 248
+  # ram_est <- stats['variants'] * stats['columns'] * 8 + 248
   ram_est <- memuse::howbig(stats['variants'], stats['columns'])
   
   if(ram_est@size > limit){

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -263,6 +263,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// vcf_stats_no_variants_gz
+Rcpp::NumericVector vcf_stats_no_variants_gz(std::string x);
+RcppExport SEXP vcfR_vcf_stats_no_variants_gz(SEXP xSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type x(xSEXP);
+    rcpp_result_gen = Rcpp::wrap(vcf_stats_no_variants_gz(x));
+    return rcpp_result_gen;
+END_RCPP
+}
 // read_meta_gz
 Rcpp::StringVector read_meta_gz(std::string x, Rcpp::NumericVector stats, int verbose);
 RcppExport SEXP vcfR_read_meta_gz(SEXP xSEXP, SEXP statsSEXP, SEXP verboseSEXP) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -264,17 +264,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// vcf_stats_no_variants_gz
-Rcpp::NumericVector vcf_stats_no_variants_gz(std::string x);
-RcppExport SEXP vcfR_vcf_stats_no_variants_gz(SEXP xSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type x(xSEXP);
-    rcpp_result_gen = Rcpp::wrap(vcf_stats_no_variants_gz(x));
-    return rcpp_result_gen;
-END_RCPP
-}
 // read_meta_gz
 Rcpp::StringVector read_meta_gz(std::string x, Rcpp::NumericVector stats, int verbose);
 RcppExport SEXP vcfR_read_meta_gz(SEXP xSEXP, SEXP statsSEXP, SEXP verboseSEXP) {

--- a/src/init.c
+++ b/src/init.c
@@ -25,6 +25,7 @@ extern SEXP vcfR_read_body_gz(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP vcfR_read_meta_gz(SEXP, SEXP, SEXP);
 extern SEXP vcfR_seq_to_rects(SEXP, SEXP);
 extern SEXP vcfR_vcf_stats_gz(SEXP);
+extern SEXP vcfR_vcf_stats_no_variants_gz(SEXP);
 extern SEXP vcfR_window_init(SEXP, SEXP);
 extern SEXP vcfR_windowize_annotations(SEXP, SEXP, SEXP, SEXP);
 extern SEXP vcfR_windowize_fasta(SEXP, SEXP);
@@ -51,6 +52,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"vcfR_read_meta_gz",          (DL_FUNC) &vcfR_read_meta_gz,          3},
     {"vcfR_seq_to_rects",          (DL_FUNC) &vcfR_seq_to_rects,          2},
     {"vcfR_vcf_stats_gz",          (DL_FUNC) &vcfR_vcf_stats_gz,          1},
+    {"vcfR_vcf_stats_no_variants_gz", (DL_FUNC) &vcfR_vcf_stats_no_variants_gz,          1},
     {"vcfR_window_init",           (DL_FUNC) &vcfR_window_init,           2},
     {"vcfR_windowize_annotations", (DL_FUNC) &vcfR_windowize_annotations, 4},
     {"vcfR_windowize_fasta",       (DL_FUNC) &vcfR_windowize_fasta,       2},


### PR DESCRIPTION
1. Created two Rcpp functions 'stat_line_no_variants' and 'vcfR_vcf_stats_no_variants_gz'.

2. Modified read.vcfR so that when the argument nrow=0, it uses 'vcfR_vcf_stats_no_variants_gz' to get the stats of the vcf file, rather than the standard version.  When there are many variants, and the user only wants the meta and the participant IDs, this can save a lot of time.