### PR TITLE
Update conversion documentation

### DIFF
--- a/R/vcfR_conversion.R
+++ b/R/vcfR_conversion.R
@@ -27,6 +27,10 @@
 #' Because 'forks' do not exist in the windows environment, this will only work for windows users when n.cores=1.
 #' In the Unix environment, users may increase this number to allow the use of multiple threads (i.e., cores).
 #' 
+#' @note \subsection{For users of \pkg{poppr}}{
+#' If you wish to use \code{vcfR2genind()}, it is \strong{strongly recommended} to use it with the option \code{return.alleles = TRUE}.
+#' The reason for this is because the \pkg{poppr} package accomodates mixed-ploidy data by interpreting "0" alleles \emph{in genind objects} to be NULL alleles in both \code{poppr::poppr.amova()} and \code{poppr::locus_table()}.
+#' }
 #' 
 #' 
 #' @seealso
@@ -109,8 +113,20 @@ vcfR2loci <- function(x, return.alleles = FALSE)
 #' @param n.cores integer specifying the number of cores to use.
 #' 
 #' @examples 
-#' data(vcfR_test)
-#' gl <- vcfR2genlight(vcfR_test)
+#' adegenet_installed <- require("adegenet")
+#' if (adegenet_installed) {
+#'   data(vcfR_test)
+#'   # convert to genlight (preferred method with bi-allelic SNPs)
+#'   gl <- vcfR2genlight(vcfR_test)
+#'   
+#'   # convert to genind, keeping information about allelic state
+#'   # (slightly slower, but preferred method for use with the "poppr" package)
+#'   gid <- vcfR2genind(vcfR_test, return.alleles = TRUE) 
+#'
+#'   # convert to genind, returning allelic states as 0, 1, 2, etc.
+#'   # (not preferred, but slightly faster)
+#'   gid2 <- vcfR2genind(vcfR_test, return.alleles = FALSE)
+#' }
 #' 
 #' @export
 vcfR2genlight <- function(x, n.cores=1){

--- a/man/vcfR_conversion.Rd
+++ b/man/vcfR_conversion.Rd
@@ -52,9 +52,27 @@ In \code{vcfR2genind} it is used to pass parameters to \code{adegenet::df2genind
 For example, setting \code{check.ploidy=FALSE} may improve the performance of \code{adegenet::df2genind}, as long as you know the ploidy.
 See \code{?adegenet::df2genind} to see these options.
 }
+\note{
+\subsection{For users of \pkg{poppr}}{
+If you wish to use \code{vcfR2genind()}, it is \strong{strongly recommended} to use it with the option \code{return.alleles = TRUE}.
+The reason for this is because the \pkg{poppr} package accomodates mixed-ploidy data by interpreting "0" alleles \emph{in genind objects} to be NULL alleles in both \code{poppr::poppr.amova()} and \code{poppr::locus_table()}.
+}
+}
 \examples{
-data(vcfR_test)
-gl <- vcfR2genlight(vcfR_test)
+adegenet_installed <- require("adegenet")
+if (adegenet_installed) {
+  data(vcfR_test)
+  # convert to genlight (preferred method with bi-allelic SNPs)
+  gl <- vcfR2genlight(vcfR_test)
+  
+  # convert to genind, keeping information about allelic state
+  # (slightly slower, but preferred method for use with the "poppr" package)
+  gid <- vcfR2genind(vcfR_test, return.alleles = TRUE) 
+
+  # convert to genind, returning allelic states as 0, 1, 2, etc.
+  # (not preferred, but slightly faster)
+  gid2 <- vcfR2genind(vcfR_test, return.alleles = FALSE)
+}
 
 }
 \seealso{


### PR DESCRIPTION
Based on [a recent topic in the poppr forum](https://groups.google.com/d/msg/poppr/2L97Uko-FK8/YgOFAbucAgAJ), it has come to my attention that there is no documentation of  why `return.alleles = TRUE` is needed, so I have added it here and I will add it to the next poppr release.

I have also added the conditional in the examples to check if adegenet is loaded since you have it in Suggests, but not Imports.