### PR TITLE
dplyr 1.0.0 fixes

### DIFF
--- a/R/vcfR_to_tidy_functions.R
+++ b/R/vcfR_to_tidy_functions.R
@@ -597,7 +597,7 @@ guess_types <- function(D) {
   tmp <- D %>%
 #    dplyr::filter_(~Number == 1) %>%
     dplyr::filter(Number == 1) %>%
-    dplyr::mutate(tt = ifelse(Type == "Integer", "i", ifelse(Type == "Numeric" | Type == "Float", "n", ""))) %>%
+    dplyr::mutate(tt = dplyr::if_else(Type == "Integer", "i", dplyr::if_else(Type == "Numeric" | Type == "Float", "n", ""))) %>%
     dplyr::filter(tt %in% c("n", "i")) %>%
 #    dplyr::filter_(~tt %in% c("n", "i")) %>%
     dplyr::select(ID, Number, Type, tt)

--- a/R/vcfR_to_tidy_functions.R
+++ b/R/vcfR_to_tidy_functions.R
@@ -605,7 +605,7 @@ guess_types <- function(D) {
 
 #  tmp <- D %>%  dplyr::filter_(~Number == 0 & Type == 'Flag')  %>%
   tmp <- D %>%  dplyr::filter(Number == 0 & Type == 'Flag')  %>%
-    dplyr::mutate(tt = ifelse(Type == "Flag", "f")) %>%
+    dplyr::mutate(tt = dplyr::if_else(Type == "Flag", "f", "")) %>%
     dplyr::filter(tt %in% c("f")) %>%
 #    dplyr::filter_(~tt %in% c("f")) %>%
     dplyr::select(ID, Number, Type, tt)  %>%


### PR DESCRIPTION
`ifelse()` returns a logical vector if the Type is length 1; `if_else()` returns a character vector. dplyr 1.0.0 is stricter about combining types so this becomes an error. This shouldn't affect vcfR with the CRAN version of dplyr.

I had to guess at the value of the third argument; you should double check it.